### PR TITLE
Minor Fixes to UI

### DIFF
--- a/frontend/src/app/external-mcp/page.tsx
+++ b/frontend/src/app/external-mcp/page.tsx
@@ -111,6 +111,8 @@ export default function ExternalMcpPage() {
               <h4 className="text-xl font-bold text-slate-900 mb-4">Create the HTTP Connection</h4>
               <p className="text-slate-700 mb-4">
                 In your Databricks workspace, navigate to <strong>Catalog</strong> → <strong>External Data</strong> → <strong>Connections</strong> and click on <strong>+ Create connection</strong> and select <strong>HTTP</strong>. Enter the following details:
+              </p>
+              <div className="space-y-3 mb-6">
                 <ul className="space-y-2 text-slate-700">
                   <li>• Connection name: github_mcp_connection_{name_prefix}</li>
                   <li>• Connection type: HTTP</li>
@@ -124,7 +126,7 @@ export default function ExternalMcpPage() {
                   <li>• Check "Is MCP connection" (set to True)</li>
                   <li>• Click <strong>Create connection</strong></li>
                 </ul>
-              </p>
+              </div>
               
               <CodeBlock
                 language="sql"

--- a/frontend/src/app/external-mcp/page.tsx
+++ b/frontend/src/app/external-mcp/page.tsx
@@ -97,7 +97,7 @@ export default function ExternalMcpPage() {
               <div className="space-y-3 mb-6">
                 <div className="border-2 border-blue-200 rounded-xl p-4 bg-blue-50">
                   <p className="text-slate-700 mb-2">
-                    <strong>1.</strong> Go to <a href="https://github.com/settings/apps" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline font-semibold">GitHub Settings → Personal Access Tokens</a>
+                    <strong>1.</strong> Go to <a href="https://github.com/settings/apps" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline font-semibold">Developer Settings → Personal Access Tokens</a>
                   </p>
                   <p className="text-slate-700 mb-2">
                     <strong>2.</strong> Create a new token (fine-grained or classic)
@@ -110,12 +110,25 @@ export default function ExternalMcpPage() {
 
               <h4 className="text-xl font-bold text-slate-900 mb-4">Create the HTTP Connection</h4>
               <p className="text-slate-700 mb-4">
-                In your Databricks workspace, navigate to <strong>Catalog</strong> → <strong>External Data</strong> → <strong>Connections</strong>
+                In your Databricks workspace, navigate to <strong>Catalog</strong> → <strong>External Data</strong> → <strong>Connections</strong> and click on <strong>+ Create connection</strong> and select <strong>HTTP</strong>. Enter the following details:
+                <ul className="space-y-2 text-slate-700">
+                  <li>• Connection name: github_mcp_connection_{name_prefix}</li>
+                  <li>• Connection type: HTTP</li>
+                  <li>• Auth type: Bearer token</li>
+                  <li>• Click <strong>Next</strong></li>
+                  <li>• Host: https://api.github.com</li>
+                  <li>• Port: 443</li>
+                  <li>• Bearer token: <insert_token_here></insert_token_here></li>
+                  <li>• Click <strong>Create</strong></li>
+                  <li>• Base path: /mcp</li>
+                  <li>• Check "Is MCP connection" (set to True)</li>
+                  <li>• Click <strong>Create connection</strong></li>
+                </ul>
               </p>
               
               <CodeBlock
                 language="sql"
-                title="Create GitHub MCP Connection"
+                title="[Alternative] Create GitHub MCP Connection programmatically using SQL (SQL Editor or Notebook)"
                 code={`-- Create HTTP connection for GitHub MCP server
 -- Replace {name_prefix} with your unique identifier (e.g., your username)
 -- Replace <insert_token_here> with your GitHub Personal Access Token

--- a/frontend/src/app/managed-mcp/page.tsx
+++ b/frontend/src/app/managed-mcp/page.tsx
@@ -444,13 +444,13 @@ RETURN
                       <div className="bg-white rounded-lg p-4 border border-blue-200">
                         <p className="font-semibold text-slate-900 mb-2">Test Query 2: Product Performance</p>
                         <code className="block p-3 bg-slate-50 rounded text-slate-800 font-mono text-sm mb-3">
-                          "What are the highest priced sporting goods?"
+                          "What are the highest priced sporting items?"
                         </code>
                         <div className="text-xs text-slate-600">
                           <p className="font-semibold mb-1">Expected behavior:</p>
                           <ul className="list-disc ml-5 space-y-1">
                             <li>LLM should call <code className="bg-slate-200 px-1 py-0.5 rounded">get_product_performance("Sports")</code></li>
-                            <li>Should understand "sporting goods" maps to the "Sports" category</li>
+                            <li>Should understand "sporting items" maps to the "Sports" category</li>
                             <li>Returns product performance data sorted by price</li>
                             <li>May highlight products with high prices and their sales performance</li>
                           </ul>
@@ -469,7 +469,7 @@ RETURN
                   </li>
                   <li className="flex items-start gap-2">
                     <span className="text-blue-600 mt-0.5">✓</span>
-                    <span><strong>Parameter understanding:</strong> The LLM should understand natural language queries and map them to the correct parameter values (e.g., "sporting goods" → "Sports")</span>
+                    <span><strong>Parameter understanding:</strong> The LLM should understand natural language queries and map them to the correct parameter values (e.g., "sporting items" → "Sports")</span>
                   </li>
                   <li className="flex items-start gap-2">
                     <span className="text-blue-600 mt-0.5">✓</span>
@@ -688,9 +688,9 @@ Common questions users might ask:
                 </div>
 
                 <div className="border border-slate-200 rounded-lg p-4 bg-slate-50">
-                  <h5 className="font-bold text-slate-900 mb-2">Step 3: Add Genie Space</h5>
+                  <h5 className="font-bold text-slate-900 mb-2">Step 3: Add Genie Space as (Databricks Managed) MCP Server</h5>
                   <p className="text-slate-700 text-sm">
-                    Add your Genie space as another tool by entering your Genie space endpoint URL.
+                    Add your Genie space as another tool by clicking on <strong>Tools → + Add tool</strong> and select <strong>MCP Servers</strong>. Add your personalized Genie Space from the dropdown.
                   </p>
                 </div>
               </div>

--- a/setup.sh
+++ b/setup.sh
@@ -57,7 +57,9 @@ clean_username() {
     # Take first part before @ or . and clean it
     local first_part=$(echo "$username" | cut -d'@' -f1 | cut -d'.' -f1)
     # Convert to lowercase, replace spaces and hyphens with underscores, remove special chars
-    echo "$first_part" | tr '[:upper:]' '[:lower:]' | tr ' -' '__' | sed 's/[^a-z0-9_]//g' | sed 's/__*/_/g' | sed 's/^_//' | sed 's/_$//'
+    local cleaned=$(echo "$first_part" | tr '[:upper:]' '[:lower:]' | tr ' -' '__' | sed 's/[^a-z0-9_]//g' | sed 's/__*/_/g' | sed 's/^_//' | sed 's/_$//')
+    # Crop to first 12 characters to respect Databricks Apps Name limit
+    echo "$cleaned" | cut -c1-12
 }
 
 # Function to update or add a value in .env.local


### PR DESCRIPTION
Added more details for Creating HTTP Connection flow

Updated the clean_username() function in setup.sh to enforce a 12-character limit on participant prefixes. This prevents Databricks Apps naming conflicts and ensures compliance with naming constraints.

Changes:
- Modified clean_username() to crop cleaned usernames to 12 chars max
- Prevents resource name overflow when creating MCP server apps
- Maintains backward compatibility with existing naming logic

This ensures resources like 'mcp-custom-server-{prefix}' stay within Databricks Apps naming limits even for participants with long usernames.

🤖 Generated with support from [Claude Code](https://claude.com/claude-code)